### PR TITLE
Auto complete

### DIFF
--- a/rapid-git.sh
+++ b/rapid-git.sh
@@ -737,7 +737,7 @@ _rapid_complete()
   local cur="${COMP_WORDS[COMP_CWORD]}"
 
   if [[ $COMP_CWORD -eq 1 ]] ; then
-    local cmds=""
+    local cmds="branch checkout diff drop merge push rebase remove stage status track unstage"
     COMPREPLY=($(compgen -W "${cmds}" -- ${cur}))
     return 0
   fi

--- a/rapid-git.sh
+++ b/rapid-git.sh
@@ -730,3 +730,22 @@ function rapid {
   __rapid_cleanup
   return $exit_status
 }
+
+_rapid_complete() 
+{
+  COMPREPLY=()
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+
+  if [[ $COMP_CWORD -eq 1 ]] ; then
+    local cmds=""
+    COMPREPLY=($(compgen -W "${cmds}" -- ${cur}))
+    return 0
+  fi
+
+  # fallback completion
+  COMPREPLY=($(compgen -o bashdefault -o default -o nospace -f ${cur}))
+  return 0
+}
+
+complete -F _rapid_complete rapid
+


### PR DESCRIPTION
Please check contained 83070605aa51c4f63a8a117c4f1f4c2348324b26. Not sure why the `IFS` variable needs to be set there at all and if it breaks anything prefixing it with `local`. I bet you possibly corrupted other auto completion libraries accidentally. See also `-W` parameter for `complete` command: https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html
